### PR TITLE
Use chain.invoke instead of chain.run when running MultiPromptChain

### DIFF
--- a/04_Chains/advanced_chains.ipynb
+++ b/04_Chains/advanced_chains.ipynb
@@ -210,7 +210,7 @@
     "    verbose=True,\n",
     ")\n",
     "\n",
-    "chain.run(\"I ordered Pizza Salami for 9.99$ and it was awesome!\")"
+    "chain.invoke({\"input\": \"I ordered Pizza Salami for 9.99$ and it was awesome!\"})"
    ]
   }
  ],


### PR DESCRIPTION
LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.